### PR TITLE
Add undock timeout duration parameter

### DIFF
--- a/include/fetch_auto_dock/auto_dock.h
+++ b/include/fetch_auto_dock/auto_dock.h
@@ -163,7 +163,7 @@ private:
   ros::Time deadline_docking_;       // Time when the docking times out.
   ros::Time deadline_not_charging_;  // Time when robot gives up on the charge state and retries docking.
   bool charging_timeout_set_;        // Flag to indicate if the deadline_not_charging has been set.
-  double duration_timeout_undock_;   // Duration for dock/undock action timeout
+  double duration_timeout_undock_;   // Duration for undock action timeout
 };
 
 #endif  // FETCH_AUTO_DOCK_H

--- a/include/fetch_auto_dock/auto_dock.h
+++ b/include/fetch_auto_dock/auto_dock.h
@@ -163,6 +163,7 @@ private:
   ros::Time deadline_docking_;       // Time when the docking times out.
   ros::Time deadline_not_charging_;  // Time when robot gives up on the charge state and retries docking.
   bool charging_timeout_set_;        // Flag to indicate if the deadline_not_charging has been set.
+  double duration_timeout_undock_;   // Duration for dock/undock action timeout
 };
 
 #endif  // FETCH_AUTO_DOCK_H

--- a/src/auto_dock.cpp
+++ b/src/auto_dock.cpp
@@ -44,6 +44,7 @@ AutoDocking::AutoDocking() :
   pnh.param("num_of_retries",                    NUM_OF_RETRIES_,                    5);
   pnh.param("dock_connector_clearance_distance", DOCK_CONNECTOR_CLEARANCE_DISTANCE_, 0.2);
   pnh.param("docked_distance_threshold",         DOCKED_DISTANCE_THRESHOLD_,         0.34);
+  pnh.param("duration_timeout_undock",           duration_timeout_undock_,           5.0);
 
   // Subscribe to robot state
   state_ = nh_.subscribe<fetch_driver_msgs::RobotState>("robot_state",
@@ -429,7 +430,7 @@ void AutoDocking::undockCallback(const fetch_auto_dock_msgs::UndockGoalConstPtr&
   controller_.stop();
 
   // Timeout for undocking
-  ros::Time timeout = ros::Time::now() + ros::Duration(5.0);
+  ros::Time timeout = ros::Time::now() + ros::Duration(duration_timeout_undock_);
 
   // Control
   ros::Rate r(50.0);


### PR DESCRIPTION
Make timeout duration for undocing to be a ros parameter.

Our Fetch sometimes fails to undock even it looks successfully to have undocked.
This comes from default timeout duration for undocking (5.0 secs) is almost same as duration to undock and rotate.
This parameter enables to reduce this situation.